### PR TITLE
Use build-arg defaults for versions

### DIFF
--- a/.github/workflows/build-push-artifacts.yaml
+++ b/.github/workflows/build-push-artifacts.yaml
@@ -21,13 +21,6 @@ on:
         description: The chart version that was published
         value: ${{ jobs.build_push_chart.outputs.chart-version }}
 
-# Variables controlling the dependencies that are baked in to the image
-env:
-  HELM_VERSION: v3.13.3
-  DEX_CHART_NAME: dex
-  DEX_CHART_REPO: https://charts.dexidp.io
-  DEX_CHART_VERSION: 0.15.3
-
 jobs:
   build_push_images:
     name: Build and push images
@@ -62,11 +55,6 @@ jobs:
           cache-key: azimuth-identity-operator
           context: .
           platforms: linux/amd64,linux/arm64
-          build-args: |
-            HELM_VERSION=${{ env.HELM_VERSION }}
-            DEX_CHART_NAME=${{ env.DEX_CHART_NAME }}
-            DEX_CHART_REPO=${{ env.DEX_CHART_REPO }}
-            DEX_CHART_VERSION=${{ env.DEX_CHART_VERSION }}
           push: true
           tags: ${{ steps.image-meta.outputs.tags }}
           labels: ${{ steps.image-meta.outputs.labels }}

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -24,9 +24,9 @@ jobs:
       - name: Update dependency key
         uses: stackhpc/github-actions/config-update@master
         with:
-          path: ./.github/workflows/build-push-artifacts.yaml
+          path: ./Dockerfile
           updates: |
-            env.HELM_VERSION=${{ steps.next.outputs.version }}
+            HELM_VERSION=${{ steps.next.outputs.version }}
 
       - name: Generate app token for PR
         uses: stackhpc/github-actions/generate-app-token@master
@@ -60,10 +60,10 @@ jobs:
         include:
           # The baked in Dex chart
           - key: dex
-            path: ./.github/workflows/build-push-artifacts.yaml
-            chart_name_jsonpath: env.DEX_CHART_NAME
-            chart_repo_jsonpath: env.DEX_CHART_REPO
-            chart_version_jsonpath: env.DEX_CHART_VERSION
+            path: ./Dockerfile
+            chart_name_jsonpath: DEX_CHART_NAME
+            chart_repo_jsonpath: DEX_CHART_REPO
+            chart_version_jsonpath: DEX_CHART_VERSION
 
           # The kube-state-metrics chart from the Helm dependencies
           - key: kube-state-metrics

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && \
     apt-get install -y curl && \
     rm -rf /var/lib/apt/lists/*
 
-ARG HELM_VERSION
+ARG HELM_VERSION=v3.13.3
 RUN set -ex; \
     OS_ARCH="$(uname -m)"; \
     case "$OS_ARCH" in \
@@ -19,7 +19,7 @@ RUN set -ex; \
 # Pull and unpack the Dex chart
 ARG DEX_CHART_NAME=dex
 ARG DEX_CHART_REPO=https://charts.dexidp.io
-ARG DEX_CHART_VERSION
+ARG DEX_CHART_VERSION=0.15.3
 RUN helm pull ${DEX_CHART_NAME} \
       --repo ${DEX_CHART_REPO} \
       --version ${DEX_CHART_VERSION} \

--- a/tilt-component.yaml
+++ b/tilt-component.yaml
@@ -3,8 +3,4 @@ chart: ./chart
 images:
   azimuth-identity-operator:
     context: .
-    build_args:
-      HELM_VERSION: v3.13.2
-      # Use the latest stable version of the Dex chart
-      DEX_CHART_VERSION: ">=0.0.0"
     chart_path: image


### PR DESCRIPTION
Using env in the GHA workflow file means that changes to those values are not actually tested, due to the use of `pull_request_target`. So move back to using build-arg defaults in the `Dockerfile`.

Needs https://github.com/stackhpc/github-actions/pull/7.