### PR TITLE
Use upstream Dex image

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -14,13 +14,7 @@ tls:
 
 # Configuration for the operator
 # For all available options, see azimuth_identity/config.py
-config:
-  dex:
-    defaultValues:
-      # Use a custom Dex image until https://github.com/dexidp/dex/pull/2851 is merged and released
-      image:
-        repository: ghcr.io/stackhpc/dex
-        tag: v2.35.3-stackhpc.1
+config: {}
 
 # The image to use for the operator
 image:


### PR DESCRIPTION
Stop using the StackHPC fork of Dex. The functionality in the StackHPC fork was merged upstream in Dex v2.38.0, and the 0.17.0 version of the Dex Helm chart deploys Dev v2.39.0.